### PR TITLE
chore(deploy): add vercel deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "backend/src/server.ts",
+      "use": "@vercel/node"
+    },
+    {
+      "src": "front-end/package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "/backend/src/server.ts"
+    },
+    {
+      "source": "/:path*",
+      "destination": "/front-end/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
Added [vercel.json]file to the project root to configure deployments on the Vercel platform.

This configuration is specifically designed for the monorepo structure, defining separate build processes for the Next.js frontend and the Express.js backend.

- The `front-end` workspace is built using `@vercel/next`.
- The `backend` workspace is built using `@vercel/node`, creating serverless functions for the API.
- Rewrite rules are established to direct `/api/:path*` requests to the backend and all other requests to the frontend, enabling them to work together under a single domain.