### PR TITLE
fix(deploy): use relative path for production API calls

### DIFF
--- a/front-end/lib/api.ts
+++ b/front-end/lib/api.ts
@@ -1,4 +1,6 @@
-export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000/api/v1';
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const API_BASE = isProduction ? '/api/v1' : (process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000/api/v1');
 
 export async function api<T = any>(path: string, init: RequestInit = {}): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {


### PR DESCRIPTION
Updates the API utility to use a relative path (`/api/v1`) for the API base URL when in a production environment. This corrects an issue where the deployed frontend on Vercel was attempting to call the backend at `localhost:4000`, resulting in a connection error.