### PR TITLE
fix(deps): add missing lucia dependencies to frontend

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -73,6 +73,8 @@
     "typescript": "5.2.2",
     "uuid": "^13.0.0",
     "vaul": "^0.9.9",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "lucia": "^3.2.2",
+    "@lucia-auth/adapter-prisma": "^4.0.1"
   }
 }


### PR DESCRIPTION
Adds `lucia` and `@lucia-auth/adapter-prisma` to the `dependencies` of the `front-end` workspace.