### PR TITLE
fix(deps): align next.js version across monorepo

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -53,7 +53,7 @@
     "eslint-config-next": "13.5.1",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.446.0",
-    "next": "13.5.1",
+    "next": "15.3.4",
     "next-themes": "^0.3.0",
     "nodemailer": "^6.9.3",
     "pino": "^8.17.2",


### PR DESCRIPTION
Upgrades the `next` package in the `front-end` workspace from version 13.5.1 to 15.3.4.